### PR TITLE
[Player] feat : Player Damage States

### DIFF
--- a/Assets/Art/TempResource/Temp_Character/DEATH.png.meta
+++ b/Assets/Art/TempResource/Temp_Character/DEATH.png.meta
@@ -136,12 +136,12 @@ TextureImporter:
       name: DEATH_0
       rect:
         serializedVersion: 2
-        x: 33
-        y: 21
-        width: 28
-        height: 37
+        x: 34
+        y: 22
+        width: 26
+        height: 35
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -158,12 +158,12 @@ TextureImporter:
       name: DEATH_1
       rect:
         serializedVersion: 2
-        x: 124
-        y: 21
-        width: 34
-        height: 36
+        x: 125
+        y: 22
+        width: 32
+        height: 35
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -180,12 +180,12 @@ TextureImporter:
       name: DEATH_2
       rect:
         serializedVersion: 2
-        x: 218
-        y: 21
-        width: 36
-        height: 34
+        x: 219
+        y: 22
+        width: 34
+        height: 35
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -202,12 +202,12 @@ TextureImporter:
       name: DEATH_3
       rect:
         serializedVersion: 2
-        x: 315
-        y: 21
-        width: 37
-        height: 30
+        x: 316
+        y: 22
+        width: 35
+        height: 35
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -224,12 +224,12 @@ TextureImporter:
       name: DEATH_4
       rect:
         serializedVersion: 2
-        x: 410
-        y: 21
-        width: 38
-        height: 31
+        x: 411
+        y: 22
+        width: 36
+        height: 35
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -246,12 +246,12 @@ TextureImporter:
       name: DEATH_5
       rect:
         serializedVersion: 2
-        x: 507
-        y: 21
-        width: 38
-        height: 31
+        x: 508
+        y: 22
+        width: 36
+        height: 35
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -268,12 +268,12 @@ TextureImporter:
       name: DEATH_6
       rect:
         serializedVersion: 2
-        x: 606
-        y: 21
-        width: 36
-        height: 31
+        x: 607
+        y: 22
+        width: 34
+        height: 35
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -290,12 +290,12 @@ TextureImporter:
       name: DEATH_7
       rect:
         serializedVersion: 2
-        x: 704
-        y: 21
-        width: 35
-        height: 31
+        x: 705
+        y: 22
+        width: 33
+        height: 35
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -312,12 +312,12 @@ TextureImporter:
       name: DEATH_8
       rect:
         serializedVersion: 2
-        x: 802
-        y: 21
-        width: 36
-        height: 25
+        x: 803
+        y: 22
+        width: 34
+        height: 35
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -334,12 +334,12 @@ TextureImporter:
       name: DEATH_9
       rect:
         serializedVersion: 2
-        x: 903
-        y: 21
-        width: 38
-        height: 25
+        x: 904
+        y: 22
+        width: 36
+        height: 35
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -356,12 +356,12 @@ TextureImporter:
       name: DEATH_10
       rect:
         serializedVersion: 2
-        x: 999
-        y: 21
-        width: 38
-        height: 21
+        x: 1000
+        y: 22
+        width: 36
+        height: 35
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -378,12 +378,12 @@ TextureImporter:
       name: DEATH_11
       rect:
         serializedVersion: 2
-        x: 1095
-        y: 21
-        width: 38
-        height: 16
+        x: 1096
+        y: 22
+        width: 36
+        height: 35
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -400,7 +400,7 @@ TextureImporter:
     customData: 
     physicsShape: []
     bones: []
-    spriteID: 
+    spriteID: 01e50dc0d88d26f46b3cfd238513ca19
     internalID: 0
     vertices: []
     indices: 

--- a/Assets/Art/TempResource/Temp_Character/HURT.png.meta
+++ b/Assets/Art/TempResource/Temp_Character/HURT.png.meta
@@ -112,12 +112,12 @@ TextureImporter:
       name: HURT_0
       rect:
         serializedVersion: 2
-        x: 33
-        y: 21
-        width: 26
-        height: 38
+        x: 34
+        y: 22
+        width: 24
+        height: 36
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -134,12 +134,12 @@ TextureImporter:
       name: HURT_1
       rect:
         serializedVersion: 2
-        x: 123
-        y: 21
-        width: 34
-        height: 38
+        x: 124
+        y: 22
+        width: 32
+        height: 36
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -156,12 +156,12 @@ TextureImporter:
       name: HURT_2
       rect:
         serializedVersion: 2
-        x: 219
-        y: 21
-        width: 34
-        height: 38
+        x: 220
+        y: 22
+        width: 32
+        height: 36
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -178,12 +178,12 @@ TextureImporter:
       name: HURT_3
       rect:
         serializedVersion: 2
-        x: 318
-        y: 21
-        width: 31
-        height: 38
+        x: 319
+        y: 22
+        width: 29
+        height: 36
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -200,7 +200,7 @@ TextureImporter:
     customData: 
     physicsShape: []
     bones: []
-    spriteID: 
+    spriteID: 64da8b546a4e47345bc68a73ba641b8f
     internalID: 0
     vertices: []
     indices: 

--- a/Assets/Art/TempResource/Temp_Character/Temp_Character_Animations/Player_Animator_Controller.controller
+++ b/Assets/Art/TempResource/Temp_Character/Temp_Character_Animations/Player_Animator_Controller.controller
@@ -77,6 +77,57 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
+--- !u!1102 &-6453080638264964079
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Player_Death
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: 52a4ad38666728a4193cdb134f74a49e, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1101 &-4459583388952366990
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Death
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -6453080638264964079}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0.75
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1101 &-3678950113740358786
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
@@ -178,6 +229,18 @@ AnimatorController:
     m_DefaultInt: 0
     m_DefaultBool: 0
     m_Controller: {fileID: 9100000}
+  - m_Name: Hurt
+    m_Type: 9
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 9100000}
+  - m_Name: Death
+    m_Type: 9
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 9100000}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer
@@ -218,6 +281,53 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
+--- !u!1101 &456202510802996623
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Hurt
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 8273148314622236544}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0.75
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1101 &2027156021314061965
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions: []
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 387033086231487081}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.1
+  m_TransitionOffset: 0
+  m_ExitTime: 0.25
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1101 &2316150386279503499
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
@@ -254,23 +364,31 @@ AnimatorStateMachine:
     m_Position: {x: 250, y: 30, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -8403904111422093237}
-    m_Position: {x: 250, y: -170, z: 0}
+    m_Position: {x: 400, y: -110, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 5800908583290255979}
     m_Position: {x: 250, y: 120, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -888671956923166910}
-    m_Position: {x: 30, y: -80, z: 0}
+    m_Position: {x: -40, y: -110, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 8273148314622236544}
+    m_Position: {x: 190, y: -110, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: -6453080638264964079}
+    m_Position: {x: 520, y: -180, z: 0}
   m_ChildStateMachines: []
   m_AnyStateTransitions:
   - {fileID: -8804600502367449197}
   - {fileID: -5698468045533633}
+  - {fileID: 456202510802996623}
+  - {fileID: -4459583388952366990}
   m_EntryTransitions: []
   m_StateMachineTransitions: {}
   m_StateMachineBehaviours: []
-  m_AnyStatePosition: {x: 40, y: -160, z: 0}
+  m_AnyStatePosition: {x: 250, y: -190, z: 0}
   m_EntryPosition: {x: 40, y: 30, z: 0}
-  m_ExitPosition: {x: 510, y: 80, z: 0}
+  m_ExitPosition: {x: 540, y: 40, z: 0}
   m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
   m_DefaultState: {fileID: 387033086231487081}
 --- !u!1102 &5800908583290255979
@@ -295,6 +413,33 @@ AnimatorState:
   m_CycleOffsetParameterActive: 0
   m_TimeParameterActive: 0
   m_Motion: {fileID: 7400000, guid: aa6e7a7dbd183be4091d66c12f76d501, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1102 &8273148314622236544
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Player_Hurt
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: 2027156021314061965}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: 102490d979a15a3469eecb5dd37565fc, type: 2}
   m_Tag: 
   m_SpeedParameter: 
   m_MirrorParameter: 

--- a/Assets/Art/TempResource/Temp_Character/Temp_Character_Animations/Player_Death.anim
+++ b/Assets/Art/TempResource/Temp_Character/Temp_Character_Animations/Player_Death.anim
@@ -1,0 +1,105 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Player_Death
+  serializedVersion: 7
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves:
+  - serializedVersion: 2
+    curve:
+    - time: 0
+      value: {fileID: -1745646317731160461, guid: 23bca72686a7e914eb8ccf17a384a4b4, type: 3}
+    - time: 0.1
+      value: {fileID: -1962882971833571424, guid: 23bca72686a7e914eb8ccf17a384a4b4, type: 3}
+    - time: 0.2
+      value: {fileID: 7163519229324203079, guid: 23bca72686a7e914eb8ccf17a384a4b4, type: 3}
+    - time: 0.3
+      value: {fileID: -2824850348822682002, guid: 23bca72686a7e914eb8ccf17a384a4b4, type: 3}
+    - time: 0.4
+      value: {fileID: -4395442915117589123, guid: 23bca72686a7e914eb8ccf17a384a4b4, type: 3}
+    - time: 0.5
+      value: {fileID: 7527047216810660112, guid: 23bca72686a7e914eb8ccf17a384a4b4, type: 3}
+    - time: 0.6
+      value: {fileID: -6116082883535636463, guid: 23bca72686a7e914eb8ccf17a384a4b4, type: 3}
+    - time: 0.7
+      value: {fileID: -5775218795824829258, guid: 23bca72686a7e914eb8ccf17a384a4b4, type: 3}
+    - time: 0.8
+      value: {fileID: -5608201998214337042, guid: 23bca72686a7e914eb8ccf17a384a4b4, type: 3}
+    - time: 0.9
+      value: {fileID: 6576388434661106147, guid: 23bca72686a7e914eb8ccf17a384a4b4, type: 3}
+    - time: 1
+      value: {fileID: -1154471196408308341, guid: 23bca72686a7e914eb8ccf17a384a4b4, type: 3}
+    - time: 1.1
+      value: {fileID: 2149593603886717485, guid: 23bca72686a7e914eb8ccf17a384a4b4, type: 3}
+    attribute: m_Sprite
+    path: 
+    classID: 212
+    script: {fileID: 0}
+    flags: 2
+  m_SampleRate: 10
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 0
+      script: {fileID: 0}
+      typeID: 212
+      customType: 23
+      isPPtrCurve: 1
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
+    pptrCurveMapping:
+    - {fileID: -1745646317731160461, guid: 23bca72686a7e914eb8ccf17a384a4b4, type: 3}
+    - {fileID: -1962882971833571424, guid: 23bca72686a7e914eb8ccf17a384a4b4, type: 3}
+    - {fileID: 7163519229324203079, guid: 23bca72686a7e914eb8ccf17a384a4b4, type: 3}
+    - {fileID: -2824850348822682002, guid: 23bca72686a7e914eb8ccf17a384a4b4, type: 3}
+    - {fileID: -4395442915117589123, guid: 23bca72686a7e914eb8ccf17a384a4b4, type: 3}
+    - {fileID: 7527047216810660112, guid: 23bca72686a7e914eb8ccf17a384a4b4, type: 3}
+    - {fileID: -6116082883535636463, guid: 23bca72686a7e914eb8ccf17a384a4b4, type: 3}
+    - {fileID: -5775218795824829258, guid: 23bca72686a7e914eb8ccf17a384a4b4, type: 3}
+    - {fileID: -5608201998214337042, guid: 23bca72686a7e914eb8ccf17a384a4b4, type: 3}
+    - {fileID: 6576388434661106147, guid: 23bca72686a7e914eb8ccf17a384a4b4, type: 3}
+    - {fileID: -1154471196408308341, guid: 23bca72686a7e914eb8ccf17a384a4b4, type: 3}
+    - {fileID: 2149593603886717485, guid: 23bca72686a7e914eb8ccf17a384a4b4, type: 3}
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 1.2
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 0
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves: []
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/Assets/Art/TempResource/Temp_Character/Temp_Character_Animations/Player_Death.anim.meta
+++ b/Assets/Art/TempResource/Temp_Character/Temp_Character_Animations/Player_Death.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 52a4ad38666728a4193cdb134f74a49e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Art/TempResource/Temp_Character/Temp_Character_Animations/Player_Hurt.anim
+++ b/Assets/Art/TempResource/Temp_Character/Temp_Character_Animations/Player_Hurt.anim
@@ -1,0 +1,81 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Player_Hurt
+  serializedVersion: 7
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves:
+  - serializedVersion: 2
+    curve:
+    - time: 0
+      value: {fileID: 3571635775238715396, guid: 874542f9408a160488d953cb31350573, type: 3}
+    - time: 0.1
+      value: {fileID: -6552392919759675800, guid: 874542f9408a160488d953cb31350573, type: 3}
+    - time: 0.2
+      value: {fileID: -4191814458887339610, guid: 874542f9408a160488d953cb31350573, type: 3}
+    - time: 0.3
+      value: {fileID: -5703626821815436037, guid: 874542f9408a160488d953cb31350573, type: 3}
+    attribute: m_Sprite
+    path: 
+    classID: 212
+    script: {fileID: 0}
+    flags: 2
+  m_SampleRate: 10
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 0
+      script: {fileID: 0}
+      typeID: 212
+      customType: 23
+      isPPtrCurve: 1
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
+    pptrCurveMapping:
+    - {fileID: 3571635775238715396, guid: 874542f9408a160488d953cb31350573, type: 3}
+    - {fileID: -6552392919759675800, guid: 874542f9408a160488d953cb31350573, type: 3}
+    - {fileID: -4191814458887339610, guid: 874542f9408a160488d953cb31350573, type: 3}
+    - {fileID: -5703626821815436037, guid: 874542f9408a160488d953cb31350573, type: 3}
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 0.4
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 1
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves: []
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/Assets/Art/TempResource/Temp_Character/Temp_Character_Animations/Player_Hurt.anim.meta
+++ b/Assets/Art/TempResource/Temp_Character/Temp_Character_Animations/Player_Hurt.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 102490d979a15a3469eecb5dd37565fc
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Docs.meta
+++ b/Assets/Docs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: af5e18051601d564e8a954f681c10a05
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Docs/Player Damage Apply & Enemy Attack Usage Guide.txt
+++ b/Assets/Docs/Player Damage Apply & Enemy Attack Usage Guide.txt
@@ -1,0 +1,128 @@
+# 작성자 : Ahyun
+# 최종 수정일 : 2025-10-12
+# 내용 : 플레이어 피해 처리 및 적 공격 연동 가이드
+===================================
+1. 일반 데미지 및 피격 처리
+=> StatManager를 통해 데미지를 주면, StatManager의 OnHurt 이벤트가 발동되어
+     PlayerDamageStateManager가 ExecuteHitState 코루틴을 자동 실행합니다.
+[예시]
+void AttackPlayer(StatManager playerStat, float attackPower)
+{
+    playerStat.TakeDamage(attackPower);
+}
+
+2. 스턴 상태 적용
+=> 적의 공격이 스턴 효과를 가지고 있을 때 사용
+[예시]
+void ApplyStun(PlayerDamageStateManager playerDamageManager, float stunTime)
+{
+    playerStat.TakeDamage(10f); 	// 데미지 처리
+    playerDamageManager.StartStun(stunTime);	// 플레이어에게 스턴 적용
+}
+
+3. 넉백 상태 적용
+=> 적의 공격이 플레이어를 밀어낼 때 사용
+[예시]
+void ApplyKnockback(PlayerDamageStateManager playerDamageManager, float knockbackForce)
+{
+    playerStat.TakeDamage(10f); 	// 데미지 처리
+    playerDamageManager.StartKnockback(knockbackForce);   // 넉백 적용
+}
+
+===================================
+[플레이어 피해 처리 테스트 코드]
+=> 하단의 테스트 스크립트를 만들고, 플레이어 오브젝트에 스크립트를 추가
+   인스펙터에서 테스트 스크립트를 우클릭해서 ContextMenu의 함수를 실행하여 테스트를 진행
+using UnityEngine;
+
+public class DamageStateTest : MonoBehaviour
+{
+    private StatManager statManager;
+    private PlayerDamageStateManager damageStateManager;
+
+    [Header("Test Settings")]
+    [SerializeField] private float testDamageAmount = 10f;
+    [SerializeField] private float testStunDuration = 5f;
+    [SerializeField] private float testKnockbackForce = 5f;
+
+    private void Awake()
+    {
+        // 필요한 컴포넌트 참조 획득
+        statManager = GetComponent<StatManager>();
+        damageStateManager = GetComponent<PlayerDamageStateManager>();
+
+        if (statManager == null || damageStateManager == null)
+        {
+            Debug.LogError("StatManager 또는 PlayerDamageStateManager가 플레이어 오브젝트에 없습니다.");
+            enabled = false;
+        }
+    }
+
+    // 현재 HP 정보를 포맷하여 반환하는 헬퍼 함수
+    private string GetHPInfo()
+    {
+        if (statManager == null) return "HP: (StatManager Not Found)";
+        
+        return $"HP: {statManager.CurrentHP:F1}/{statManager.MaxHP:F1}"; // 소수점 첫째 자리까지 표시
+    }
+
+    // ----------------------------------------------------
+    // I. 일반 피격 테스트 (StatManager -> DamageStateManager.Hit)
+    // ----------------------------------------------------
+    [ContextMenu("TEST 1: 일반 피격 (Hit State)")]
+    private void TestHitState()
+    {
+        // StatManager를 통해 데미지를 입혀 Hit 상태 로직이 시작되도록 유도
+        Debug.Log($"<color=yellow>[TEST]</color> --- TEST 1: 일반 피격 시작 (Damage: {testDamageAmount}) --- **{GetHPInfo()}**");
+        statManager.TakeDamage(testDamageAmount);
+    }
+
+    // ----------------------------------------------------
+    // II. 스턴 테스트 (DamageStateManager.Stunned)
+    // ----------------------------------------------------
+    [ContextMenu("TEST 2: 스턴 상태 (Stunned)")]
+    private void TestStunState()
+    {
+        Debug.Log($"<color=orange>[TEST]</color> --- TEST 2: 스턴 상태 시작 (Duration: {testStunDuration}s) --- **{GetHPInfo()}**");
+        // DamageStateManager의 Public 함수를 직접 호출
+        damageStateManager.StartStun(testStunDuration);
+    }
+
+    // ----------------------------------------------------
+    // III. 넉백 테스트 (DamageStateManager.Knockback)
+    // ----------------------------------------------------
+    [ContextMenu("TEST 3: 넉백 상태 (Knockback Right)")]
+    private void TestKnockbackState()
+    {
+        Debug.Log($"<color=teal>[TEST]</color> --- TEST 3: 넉백 상태 시작 (Force: {testKnockbackForce}) --- **{GetHPInfo()}**");
+        damageStateManager.StartKnockback(testKnockbackForce);
+    }
+
+    // ----------------------------------------------------
+    // IV. 사망 테스트 (StatManager -> DamageStateManager.Dead)
+    // ----------------------------------------------------
+    [ContextMenu("TEST 4: 사망 처리 (Death)")]
+    private void TestDeathState()
+    {
+        // StatManager에 대량의 피해를 입혀 사망 이벤트가 발생하도록 유도
+        float massiveDamage = statManager.CurrentHP + 1000f;
+        Debug.Log($"<color=red>[TEST]</color> --- TEST 4: 사망 처리 시작 (Damage: {massiveDamage}) --- **{GetHPInfo()}**");
+        statManager.TakeDamage(massiveDamage);
+    }
+
+    // ----------------------------------------------------
+    // V. 상태 복구 테스트
+    // ----------------------------------------------------
+    [ContextMenu("TEST 5: HP 만땅 회복")]
+    private void TestHeal()
+    {
+        statManager.HealHP(statManager.MaxHP);
+        
+        // 사망 상태에서 복구할 경우 입력 및 애니메이션 컨트롤러를 다시 활성화합니다.
+        // 일반적인 게임에서는 씬 전환 등으로 처리되지만 테스트를 위해 강제 활성화합니다.
+        if (GetComponent<PlayerInput>() != null) GetComponent<PlayerInput>().enabled = true;
+        if (GetComponent<PlayerAniController>() != null) GetComponent<PlayerAniController>().enabled = true;
+
+        Debug.Log($"<color=green>[TEST]</color> HP 만땅 회복 및 입력 복구. **{GetHPInfo()}**");
+    }
+}

--- a/Assets/Docs/Player Damage Apply & Enemy Attack Usage Guide.txt.meta
+++ b/Assets/Docs/Player Damage Apply & Enemy Attack Usage Guide.txt.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: bb3755fdff7481a49bc91910b2e38f21
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/TestScene.unity
+++ b/Assets/Scenes/TestScene.unity
@@ -408,6 +408,7 @@ GameObject:
   - component: {fileID: 1712119492}
   - component: {fileID: 1712119491}
   - component: {fileID: 1712119493}
+  - component: {fileID: 1712119494}
   m_Layer: 0
   m_Name: Player
   m_TagString: Untagged
@@ -642,6 +643,7 @@ MonoBehaviour:
   groundCheckDistance: 0.1
   groundCheckSize: {x: 0.8, y: 0.1}
   groundCheckOffset: {x: 0, y: -0.6}
+  maxJumpCount: 2
   dashSpeed: 10
   dashDuration: 0.2
 --- !u!114 &1712119492
@@ -669,6 +671,23 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   statDataSO: {fileID: 11400000, guid: 91968ee7967c5ba45a1737e9d6a05242, type: 2}
+--- !u!114 &1712119494
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1712119481}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 62ca1bac3ccb8204787b2e86ea46c20c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  hitIgnoreDuration: 0.5
+  hitSlowdownMultiplier: 0.5
+  defaultStunDuration: 1
+  defaultKnockbackForce: 2
+  knockbackDuration: 0.15
 --- !u!1 &1895646201
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Core/StatManager.cs
+++ b/Assets/Scripts/Core/StatManager.cs
@@ -60,6 +60,9 @@ public class StatManager : MonoBehaviour
     public event Action<StatManager, float, float> OnHPChanged;
     public event Action<StatManager, float, float> OnStaminaChanged;
     public event Action<StatManager, StatType, float> OnFinalStatChanged;
+
+    // PlayerDamageStateManager에게 피격 반응을 요청하는 이벤트
+    public event Action<StatManager> OnHurt;
     public event Action OnDeath;
     #endregion
 
@@ -198,8 +201,14 @@ public class StatManager : MonoBehaviour
         currentHP = Mathf.Max(currentHP - finalDamage, 0);
         OnHPChanged?.Invoke(this, currentHP, MaxHP);
 
-        // 현재 HP가 0 이하가 된 경우 사망 이벤트 추가
-        if (currentHP <= 0)
+        // HP 감소 시 Damage State Manager에게 피격 반응 요청
+        // 사망 상태가 아니면 피격 이벤트 발생
+        if (currentHP > 0)
+        {
+            OnHurt?.Invoke(this);
+        }
+        // 현재 HP가 0 이하가 된 경우 사망 이벤트 발생
+        else
         {
             OnDeath?.Invoke();
         }

--- a/Assets/Scripts/Player/PlayerDamageStateManager.cs
+++ b/Assets/Scripts/Player/PlayerDamageStateManager.cs
@@ -1,0 +1,210 @@
+using UnityEngine;
+using System;
+using System.Collections;
+
+// 플레이어의 피해 관련 상태
+public enum DamageState
+{
+    Normal,      // 일반 상태
+    Hit,         // 피격 상태
+    Stunned,     // 스턴 상태
+    Knockback,   // 넉백 상태
+    Dead         // 사망 상태
+}
+
+/// <summary>
+/// 플레이어의 피격, 스턴, 넉백, 사망 등 피해로 인한 상태 변화 로직 관리
+/// StatManager와 이벤트 통신
+/// </summary>
+public class PlayerDamageStateManager : MonoBehaviour
+{
+    private StatManager statManager;
+    private Rigidbody2D rb;
+    private PlayerLocomotion locomotion;
+    private SpriteRenderer spriteRenderer;
+
+    [Header("Hit State Settings")]    // 피격
+    [SerializeField] private float hitIgnoreDuration = 0.5f;
+    [SerializeField] private float hitSlowdownMultiplier = 0.5f;    // 피격 시 적용할 속도 배율 (50%)
+
+    [Header("Stun State Settings")]   // 스턴(기절)
+    [SerializeField] private float defaultStunDuration = 1.0f;      // 기본 스턴 지속시간
+
+    [Header("Knockback Settings")]    // 넉백(넘어짐)
+    [SerializeField] private float defaultKnockbackForce = 2.0f;    // 기본 넉백 적용 힘
+    [SerializeField] private float knockbackDuration = 0.15f;       // 넉백 지속시간
+    
+    private DamageState currentDamageState = DamageState.Normal;
+
+    // 피격 애니메이션 요청 이벤트
+    public event Action OnPlayerHurt;
+
+    #region Properties
+    public bool IsInHitState { get; private set; } = false;
+    public DamageState CurrentDamageState => currentDamageState;
+    #endregion
+
+    private void Awake()
+    {
+        statManager = GetComponent<StatManager>();
+        rb = GetComponent<Rigidbody2D>();
+        locomotion = GetComponent<PlayerLocomotion>();
+        spriteRenderer = GetComponent<SpriteRenderer>();
+
+        if (statManager == null || rb == null || locomotion == null || spriteRenderer == null)
+        {
+            Debug.LogError("필수 컴포넌트를 찾지 못했습니다.");
+            enabled = false;
+            return;
+        }
+
+        // StatManager 이벤트 구독
+        statManager.OnHurt += HandleHit; // 피격 발생 시 호출 (HP 감소 후)
+        statManager.OnDeath += HandleDeath; 
+    }
+
+    private void OnDestroy()
+    {
+        if (statManager != null)
+        {
+            statManager.OnHurt -= HandleHit;
+            statManager.OnDeath -= HandleDeath;
+        }
+    }
+
+    // StatManager로부터 HP 감소가 발생했음을 통보받아 피격 상태 시작
+    private void HandleHit(StatManager sender)
+    {
+        // 이미 피격 or 사망 상태인 경우 피해 무시
+        if (currentDamageState == DamageState.Dead || IsInHitState)
+        {
+            return;
+        }
+
+        // 피격 상태 처리 시작
+        StartCoroutine(ExecuteHitState());
+    }
+
+    // 피격 상태를 처리하는 코루틴
+    private IEnumerator ExecuteHitState()
+    {
+        // 피격 상태로 전환
+        currentDamageState = DamageState.Hit;
+        IsInHitState = true;
+
+        // 피격 시 이동 속도 절반 감소
+        locomotion.MoveSpeedMultiplier = hitSlowdownMultiplier;
+
+        // 피격 애니메이션 실행
+        OnPlayerHurt.Invoke();
+
+        yield return new WaitForSeconds(hitIgnoreDuration);
+
+        // 피격 상태 지속시간 종료 후 일반 상태로 전환
+        currentDamageState = DamageState.Normal;
+        IsInHitState = false;
+
+        // 이동 속도 원상 복구
+        locomotion.MoveSpeedMultiplier = 1f; 
+    }
+
+    // StatManager로부터 사망 이벤트 발생을 통보받아 사망 상태 처리
+    private void HandleDeath()
+    {
+        // 이미 사망 상태인 경우 무시
+        if (currentDamageState == DamageState.Dead) return;
+
+        // 모든 코루틴 중지
+        StopAllCoroutines(); 
+
+        currentDamageState = DamageState.Dead;
+
+        // Rigidbody2D 물리 정지
+        if (rb != null)
+        {
+            rb.linearVelocity = Vector2.zero;
+        }
+
+        locomotion.MoveSpeedMultiplier = 1f;    // 이동 속도 복구
+
+        Debug.Log($"{gameObject.name} has died.");
+    }
+    #region Stun Method
+    // 스턴 상태를 시작하는 함수 (적 공격 로직에서 사용)
+    public void StartStun(float duration)
+    {
+        if (currentDamageState == DamageState.Dead || IsInHitState) return;
+
+        StartCoroutine(ExecuteStunState(defaultStunDuration + duration));
+    }
+
+    // 스턴 상태를 처리하는 처리하는 코루틴
+    private IEnumerator ExecuteStunState(float duration)
+    {
+        currentDamageState = DamageState.Stunned;
+
+        // 스턴 시 이동 비활성화 (물리 정지)
+        rb.linearVelocity = Vector2.zero;
+
+        OnPlayerHurt?.Invoke();     // 피격 애니메이션 실행
+
+        Debug.Log("스턴 상태!");
+
+        yield return new WaitForSeconds(duration);
+
+        // 스턴 상태 해제 후 일반 상태로 전환
+        if (currentDamageState != DamageState.Dead)
+        {
+            currentDamageState = DamageState.Normal;
+        }
+    }
+    #endregion
+
+    #region Knockback Method
+    // 넉백 상태를 시작하는 함수 (적 공격 로직에서 사용)
+    public void StartKnockback(float forceX)
+    {
+        if (currentDamageState == DamageState.Dead || IsInHitState) return;
+
+        StartCoroutine(ExecuteKnockbackState(defaultKnockbackForce + forceX));
+    }
+    
+    private IEnumerator ExecuteKnockbackState(float forceX)
+    {
+        currentDamageState = DamageState.Knockback;
+        IsInHitState = true; // 넉백 시 Hit 중복 실행 방지를 위해 true로 설정
+
+        // 플레이어 이동 제어 차단
+        locomotion.MoveSpeedMultiplier = 0f;
+
+        // 플레이어가 바라보는 방향의 반대로 넉백 방향 설정
+        // (flipX == true : 왼쪽을 보고 있음 (-1) , false : 오른쪽을 보고 있음 (1) )
+        float facingDirection = spriteRenderer.flipX ? -1f : 1f;
+        float knockbackDirection = -facingDirection;
+
+        // 피격 애니메이션 실행
+        OnPlayerHurt?.Invoke();
+
+        // 넉백 힘 적용
+        Vector2 knockbackForce = new Vector2(knockbackDirection * forceX, 0f);
+        rb.linearVelocity = knockbackForce;
+
+        Debug.Log("넉백 상태!");
+
+        yield return new WaitForSeconds(knockbackDuration);
+
+        // 넉백 상태 종료 및 일반 상태로 복구
+        if (currentDamageState != DamageState.Dead)
+        {
+            // 넉백 힘 제거 및 물리 정지
+            rb.linearVelocity = new Vector2(0f, rb.linearVelocity.y);
+
+            currentDamageState = DamageState.Normal;
+
+            // 이동 속도 원상 복구
+            locomotion.MoveSpeedMultiplier = 1f;
+        }
+        IsInHitState = false; 
+    }
+    #endregion
+}

--- a/Assets/Scripts/Player/PlayerDamageStateManager.cs.meta
+++ b/Assets/Scripts/Player/PlayerDamageStateManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 62ca1bac3ccb8204787b2e86ea46c20c

--- a/Assets/Scripts/Player/PlayerInput.cs
+++ b/Assets/Scripts/Player/PlayerInput.cs
@@ -8,15 +8,35 @@ using System;
 /// </summary>
 public class PlayerInput : MonoBehaviour
 {
+    private StatManager statManager;
+    private UnityEngine.InputSystem.PlayerInput inputSystem;
+
     private Vector2 moveVector;
     
     // 플레이어 입력 이벤트 선언 (점프/대시)
     public event Action OnJumpEvent;
-    public event Action OnDashEvent; 
+    public event Action OnDashEvent;
 
     #region Player Input Properties
     public Vector2 MoveVector => moveVector;
     #endregion
+
+    private void Awake()
+    {
+        statManager = GetComponent<StatManager>();
+        inputSystem = GetComponent<UnityEngine.InputSystem.PlayerInput>();
+
+        // 사망 이벤트 구독
+        statManager.OnDeath += DisableInput;
+    }
+    
+    private void OnDestroy()
+    {
+        if (statManager != null)
+        {
+            statManager.OnDeath -= DisableInput;
+        }
+    }
 
     // Move 핸들러: 이동 입력(Vector2) 처리
     void OnMove(InputValue value)
@@ -38,7 +58,25 @@ public class PlayerInput : MonoBehaviour
     {
         if (value.isPressed)
         {
-            OnDashEvent?.Invoke(); 
+            OnDashEvent?.Invoke();
         }
+    }
+    
+    // 사망 시 호출되어 플레이어 입력 비활성화
+    private void DisableInput()
+    {
+        // Input System 비활성화
+        if (inputSystem != null)
+        {
+            inputSystem.actions.Disable(); 
+        }
+        
+        // 스크립트 비활성화
+        enabled = false; 
+        
+        // 이동 벡터 초기화
+        moveVector = Vector2.zero; 
+        
+        Debug.Log("PlayerInput Disabled.");
     }
 }


### PR DESCRIPTION
## 📦 PR - 플레이어 피해 상태 구현

### 📋 Summary
플레이어의 피격, 스턴, 넉백, 사망 등을 처리하는 통합 피해 상태 관리 시스템 구현
피해 상태 시 입력 제어 및 피격/사망 애니메이션 추가

### 🔗 Related Issue
**Closes #10 **

### 🔧 Changes Made
- 'PlayerDamageStateManager' (피해 상태 관리 시스템)
   : 피격, 스턴, 넉백, 사망 상태 처리를 위한 코루틴 기반의 상태 관리 로직 구현
- 'PlayerLocomotion' : FixedUpdate()에서 이동 제한 상태인 경우 이동 제한 로직 추가
- 'PlayerInput' : 사망 이벤트 발생 시 Input System 비활성화를 통해 플레이어 입력 차단
- 'StatManager' : OnHurt (피격) 이벤트 추가
- 'PlayerAniController' : 피격/사망 상태 애니메이션 처리 로직 추가

### 🧪 How to Test
테스트를 거친 PR로 Docs 폴더에 추가한 'Player Damage Apply & Enemy Attack Usage Guide.txt' 파일에
테스트 코드 및 자세한 플레이어 피해 처리 방법을 기재
