### PR TITLE
refactor: ShadowController isolation

### DIFF
--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -22,6 +22,8 @@ GameObject:
   - component: {fileID: 7704894825232611223}
   - component: {fileID: 2517229581724690517}
   - component: {fileID: 2438790105660783979}
+  - component: {fileID: 989850997603945336}
+  - component: {fileID: 8255644337326092784}
   m_Layer: 0
   m_Name: Player
   m_TagString: Untagged
@@ -42,6 +44,7 @@ Transform:
   m_LocalScale: {x: 3, y: 3, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 6469584802622449953}
   - {fileID: 4089500519648857157}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -272,7 +275,6 @@ MonoBehaviour:
   maxJumpCount: 2
   dashSpeed: 10
   dashDuration: 0.2
-  shadowObject: {fileID: 4653774548087151021}
 --- !u!114 &2395407492373929372
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -362,7 +364,203 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   playerStat: {fileID: 2395407492373929372}
   fatigue: {fileID: 7704894825232611223}
+  playerStatus: {fileID: 0}
   hazardDamage: 2
+  isImmuneToHazardTerrain: 0
+--- !u!114 &989850997603945336
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1637058775880585263}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fa659ec6fbb43d542b3634ed0040efe7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  might: 1
+  temperance: 1
+  spirit: 1
+  insight: 1
+  agility: 1
+  shadowFragments: 20
+  upgradeCost: 1
+--- !u!114 &8255644337326092784
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1637058775880585263}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ee6ca2f2915693240980f80926f4e45d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  shadowObject: {fileID: 4653774548087151021}
+--- !u!1 &4529739750275426021
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6469584802622449953}
+  - component: {fileID: 2082115792635502911}
+  - component: {fileID: 3762785334782026836}
+  - component: {fileID: 6386578997986009392}
+  - component: {fileID: 3236762119357862386}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6469584802622449953
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4529739750275426021}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -10}
+  m_LocalScale: {x: 0.23333333, y: 0.13333334, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5877015653859284053}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!20 &2082115792635502911
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4529739750275426021}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 2
+  m_BackGroundColor: {r: 0.215671, g: 0.23305678, b: 0.2603773, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 34
+  orthographic: 1
+  orthographic size: 5.625
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 0
+  m_HDR: 1
+  m_AllowMSAA: 0
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 0
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!81 &3762785334782026836
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4529739750275426021}
+  m_Enabled: 1
+--- !u!114 &6386578997986009392
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4529739750275426021}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_RenderShadows: 1
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 0
+  m_Cameras: []
+  m_RendererIndex: -1
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_VolumeFrameworkUpdateModeOption: 2
+  m_RenderPostProcessing: 0
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 0
+  m_ClearDepth: 1
+  m_AllowXRRendering: 1
+  m_AllowHDROutput: 1
+  m_UseScreenCoordOverride: 0
+  m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_Version: 2
+  m_TaaSettings:
+    m_Quality: 3
+    m_FrameInfluence: 0.1
+    m_JitterScale: 1
+    m_MipBias: 0
+    m_VarianceClampScale: 0.9
+    m_ContrastAdaptiveSharpening: 0
+--- !u!114 &3236762119357862386
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4529739750275426021}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c88f5cead0c0b2a4eb05b5900433f8d1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ComponentVersion: 1
+  m_AssetsPPU: 16
+  m_RefResolutionX: 320
+  m_RefResolutionY: 180
+  m_CropFrame: 0
+  m_GridSnapping: 2
+  m_FilterMode: 0
+  m_UpscaleRT: 0
+  m_PixelSnapping: 0
+  m_CropFrameX: 0
+  m_CropFrameY: 0
+  m_StretchFill: 0
 --- !u!1 &4653774548087151021
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/B3_TestScene.unity
+++ b/Assets/Scenes/B3_TestScene.unity
@@ -1420,168 +1420,11 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!1 &519420028
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 519420032}
-  - component: {fileID: 519420031}
-  - component: {fileID: 519420029}
-  - component: {fileID: 519420030}
-  - component: {fileID: 519420033}
-  m_Layer: 0
-  m_Name: Main Camera
-  m_TagString: MainCamera
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!81 &519420029
-AudioListener:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 519420028}
-  m_Enabled: 1
---- !u!114 &519420030
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 519420028}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_RenderShadows: 1
-  m_RequiresDepthTextureOption: 2
-  m_RequiresOpaqueTextureOption: 2
-  m_CameraType: 0
-  m_Cameras: []
-  m_RendererIndex: -1
-  m_VolumeLayerMask:
-    serializedVersion: 2
-    m_Bits: 1
-  m_VolumeTrigger: {fileID: 0}
-  m_VolumeFrameworkUpdateModeOption: 2
-  m_RenderPostProcessing: 0
-  m_Antialiasing: 0
-  m_AntialiasingQuality: 2
-  m_StopNaN: 0
-  m_Dithering: 0
-  m_ClearDepth: 1
-  m_AllowXRRendering: 1
-  m_AllowHDROutput: 1
-  m_UseScreenCoordOverride: 0
-  m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
-  m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
-  m_RequiresDepthTexture: 0
-  m_RequiresColorTexture: 0
-  m_Version: 2
-  m_TaaSettings:
-    m_Quality: 3
-    m_FrameInfluence: 0.1
-    m_JitterScale: 1
-    m_MipBias: 0
-    m_VarianceClampScale: 0.9
-    m_ContrastAdaptiveSharpening: 0
---- !u!20 &519420031
+--- !u!20 &519420031 stripped
 Camera:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 2082115792635502911, guid: 16c9b4039cd9f8e49b8892de4e3eeadc, type: 3}
+  m_PrefabInstance: {fileID: 1404946629}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 519420028}
-  m_Enabled: 1
-  serializedVersion: 2
-  m_ClearFlags: 2
-  m_BackGroundColor: {r: 0.215671, g: 0.23305678, b: 0.2603773, a: 0}
-  m_projectionMatrixMode: 1
-  m_GateFitMode: 2
-  m_FOVAxisMode: 0
-  m_Iso: 200
-  m_ShutterSpeed: 0.005
-  m_Aperture: 16
-  m_FocusDistance: 10
-  m_FocalLength: 50
-  m_BladeCount: 5
-  m_Curvature: {x: 2, y: 11}
-  m_BarrelClipping: 0.25
-  m_Anamorphism: 0
-  m_SensorSize: {x: 36, y: 24}
-  m_LensShift: {x: 0, y: 0}
-  m_NormalizedViewPortRect:
-    serializedVersion: 2
-    x: 0
-    y: 0
-    width: 1
-    height: 1
-  near clip plane: 0.3
-  far clip plane: 1000
-  field of view: 34
-  orthographic: 1
-  orthographic size: 5.625
-  m_Depth: -1
-  m_CullingMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_RenderingPath: -1
-  m_TargetTexture: {fileID: 0}
-  m_TargetDisplay: 0
-  m_TargetEye: 0
-  m_HDR: 1
-  m_AllowMSAA: 0
-  m_AllowDynamicResolution: 0
-  m_ForceIntoRT: 0
-  m_OcclusionCulling: 0
-  m_StereoConvergence: 10
-  m_StereoSeparation: 0.022
---- !u!4 &519420032
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 519420028}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -10}
-  m_LocalScale: {x: 0.23333333, y: 0.13333334, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1437534424}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &519420033
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 519420028}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c88f5cead0c0b2a4eb05b5900433f8d1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_ComponentVersion: 1
-  m_AssetsPPU: 16
-  m_RefResolutionX: 320
-  m_RefResolutionY: 180
-  m_CropFrame: 0
-  m_GridSnapping: 2
-  m_FilterMode: 0
-  m_UpscaleRT: 0
-  m_PixelSnapping: 0
-  m_CropFrameX: 0
-  m_CropFrameY: 0
-  m_StretchFill: 0
 --- !u!1 &546441380
 GameObject:
   m_ObjectHideFlags: 0
@@ -14561,11 +14404,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1365626047}
   m_CullTransparentMesh: 1
---- !u!1 &1376371021 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 4653774548087151021, guid: 16c9b4039cd9f8e49b8892de4e3eeadc, type: 3}
-  m_PrefabInstance: {fileID: 1404946629}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1404946629
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -14577,18 +14415,6 @@ PrefabInstance:
     - target: {fileID: 1637058775880585263, guid: 16c9b4039cd9f8e49b8892de4e3eeadc, type: 3}
       propertyPath: m_Name
       value: Player
-      objectReference: {fileID: 0}
-    - target: {fileID: 2692484259772285319, guid: 16c9b4039cd9f8e49b8892de4e3eeadc, type: 3}
-      propertyPath: m_SortingOrder
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5877015653859284053, guid: 16c9b4039cd9f8e49b8892de4e3eeadc, type: 3}
-      propertyPath: m_LocalScale.x
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 5877015653859284053, guid: 16c9b4039cd9f8e49b8892de4e3eeadc, type: 3}
-      propertyPath: m_LocalScale.y
-      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 5877015653859284053, guid: 16c9b4039cd9f8e49b8892de4e3eeadc, type: 3}
       propertyPath: m_LocalPosition.x
@@ -14630,31 +14456,17 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6699945854644491822, guid: 16c9b4039cd9f8e49b8892de4e3eeadc, type: 3}
-      propertyPath: shadowObject
-      value: 
-      objectReference: {fileID: 1376371021}
-    - target: {fileID: 6883663696108421802, guid: 15a97fe51a894164e878dfa5789c9727, type: 3}
-      propertyPath: jumpForce
-      value: 10
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 5877015653859284053, guid: 16c9b4039cd9f8e49b8892de4e3eeadc, type: 3}
-      insertIndex: 0
-      addedObject: {fileID: 519420032}
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 1637058775880585263, guid: 16c9b4039cd9f8e49b8892de4e3eeadc, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 1437534436}
+    m_AddedGameObjects: []
+    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 16c9b4039cd9f8e49b8892de4e3eeadc, type: 3}
 --- !u!114 &1404946630 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 1067041546090441105, guid: 16c9b4039cd9f8e49b8892de4e3eeadc, type: 3}
   m_PrefabInstance: {fileID: 1404946629}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1437534415}
+  m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fb805802851d8a84386b9bc5abfdfb02, type: 3}
@@ -14796,35 +14608,17 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1407165170}
   m_CullTransparentMesh: 1
---- !u!1 &1437534415 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1637058775880585263, guid: 16c9b4039cd9f8e49b8892de4e3eeadc, type: 3}
-  m_PrefabInstance: {fileID: 1404946629}
-  m_PrefabAsset: {fileID: 0}
---- !u!4 &1437534424 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 5877015653859284053, guid: 16c9b4039cd9f8e49b8892de4e3eeadc, type: 3}
-  m_PrefabInstance: {fileID: 1404946629}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &1437534436
+--- !u!114 &1437534436 stripped
 MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 989850997603945336, guid: 16c9b4039cd9f8e49b8892de4e3eeadc, type: 3}
+  m_PrefabInstance: {fileID: 1404946629}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1437534415}
+  m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fa659ec6fbb43d542b3634ed0040efe7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  might: 1
-  temperance: 1
-  spirit: 1
-  insight: 1
-  agility: 1
-  shadowFragments: 20
-  upgradeCost: 1
 --- !u!1 &1456910944
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Player/PlayerLocomotion.cs
+++ b/Assets/Scripts/Player/PlayerLocomotion.cs
@@ -34,11 +34,6 @@ public class PlayerLocomotion : MonoBehaviour
     [SerializeField] private float dashDuration = 0.2f;
     private bool isDashing = false; // 대시 중 상태 관리
 
-    [Header("Shadow Settings")]
-    [SerializeField] private GameObject shadowObject;
-    private Color originalPlayerColor;
-    private bool isShadowModeActive = false;
-
     public bool IsMoving => isMoving;
     public bool IsJumping => isJumping;
     public bool IsDashing => isDashing;
@@ -52,19 +47,9 @@ public class PlayerLocomotion : MonoBehaviour
         damageStateManager = GetComponent<PlayerDamageStateManager>();
         statusManager = GetComponent<StatusEffectManager>();
 
-        // 그림자 제어 초기화
-        if (shadowObject == null)
-        {
-            Debug.LogError("Shadow 오브젝트가 연결되지 않았습니다! 인스펙터 창에서 연결해주세요.", this);
-            enabled = false;
-            return;
-        }
-        originalPlayerColor = spriteRenderer.color;
-
         // 이벤트 구독
         playerInput.OnJumpEvent += HandleJump;
         playerInput.OnDashEvent += HandleDash;
-        playerInput.OnToggleShadowEvent += HandleToggleShadow;
     }
 
     private void OnDestroy()
@@ -74,7 +59,6 @@ public class PlayerLocomotion : MonoBehaviour
         {
             playerInput.OnJumpEvent -= HandleJump;
             playerInput.OnDashEvent -= HandleDash;
-            playerInput.OnToggleShadowEvent -= HandleToggleShadow;
             
         }
     }
@@ -91,8 +75,6 @@ public class PlayerLocomotion : MonoBehaviour
                 isJumping = false;
             }
         }
-
-        HandleShadowOnJump();
 
         // 이동 제한 상태인 경우 (일반/피격 상태 제외) 이동 처리 무시
         if (damageStateManager.CurrentDamageState != DamageState.Normal &&
@@ -232,53 +214,4 @@ public class PlayerLocomotion : MonoBehaviour
 
         isDashing = false;
     }
-
-     #region Shadow Control Methods
-
-    /// <summary>
-    /// PlayerInput의 OnToggleShadowEvent 신호를 받아 그림자 모드를 토글합니다.
-    /// </summary>
-    private void HandleToggleShadow()
-    {
-        isShadowModeActive = !isShadowModeActive;
-        UpdateShadowVisuals();
-    }
-
-    /// <summary>
-    /// 그림자 모드 상태에 따라 플레이어와 그림자의 모습을 업데이트합니다.
-    /// </summary>
-    private void UpdateShadowVisuals()
-    {
-        if (isShadowModeActive)
-        {
-            // 그림자 모드 활성화: 그림자 끄고, 플레이어 검게
-            shadowObject.SetActive(false);
-            spriteRenderer.color = Color.black;
-        }
-        else
-        {
-            // 그림자 모드 비활성화: 플레이어 색상 원래대로, 그림자는 지면 상태에 따라 결정
-            spriteRenderer.color = originalPlayerColor;
-            HandleShadowOnJump(); // 상태 변경 시 즉시 그림자 상태 업데이트
-        }
-    }
-
-    /// <summary>
-    /// 플레이어의 지면 상태에 따라 그림자를 켜고 끕니다. (그림자 모드가 아닐 때만 작동)
-    /// </summary>
-    private void HandleShadowOnJump()
-    {
-        if (isShadowModeActive) return;
-
-        if (Grounded)
-        {
-            shadowObject.SetActive(true); // 땅에 있으면 그림자 켜기
-        }
-        else
-        {
-            shadowObject.SetActive(false); // 공중에 있으면 그림자 끄기
-        }
-    }
-
-    #endregion
 }

--- a/Assets/Scripts/Player/PlayerShadowController.cs
+++ b/Assets/Scripts/Player/PlayerShadowController.cs
@@ -1,0 +1,114 @@
+using UnityEngine;
+using UnityEngine.InputSystem; // Input System 사용을 위해 추가
+
+/// <summary>
+/// 플레이어의 그림자 오브젝트와 그림자 모드(C키)를 제어합니다.
+/// 점프 시 그림자를 숨기고, C키로 그림자 모드를 토글합니다.
+/// PlayerInput 이벤트를 구독하고 PlayerLocomotion의 Grounded 상태를 참조합니다.
+/// </summary>
+[RequireComponent(typeof(SpriteRenderer), typeof(PlayerLocomotion), typeof(PlayerInput))]
+public class PlayerShadowController : MonoBehaviour
+{
+    [Header("오브젝트 연결")]
+    [Tooltip("플레이어의 자식 오브젝트인 Shadow를 연결해주세요.")]
+    [SerializeField] private GameObject shadowObject;
+
+    private SpriteRenderer playerSpriteRenderer;
+    private PlayerLocomotion playerLocomotion;
+    private PlayerInput playerInput; // PlayerInput 참조 추가
+
+    private Color originalPlayerColor;
+    private bool isShadowModeActive = false; // C키로 활성화되는 그림자 모드 상태
+
+    private void Awake()
+    {
+        // 필요한 컴포넌트들을 가져옵니다.
+        playerSpriteRenderer = GetComponent<SpriteRenderer>();
+        playerLocomotion = GetComponent<PlayerLocomotion>();
+        playerInput = GetComponent<PlayerInput>(); // PlayerInput 컴포넌트 가져오기
+
+        if (shadowObject == null)
+        {
+            Debug.LogError("Shadow 오브젝트가 연결되지 않았습니다! 인스펙터 창에서 연결해주세요.", this);
+            enabled = false;
+            return;
+        }
+        if (playerInput == null) // PlayerInput 확인 추가
+        {
+             Debug.LogError("PlayerInput 컴포넌트를 찾을 수 없습니다!", this);
+            enabled = false;
+            return;
+        }
+
+        // 플레이어의 원래 색상을 저장해둡니다.
+        originalPlayerColor = playerSpriteRenderer.color;
+
+        // PlayerInput의 그림자 토글 이벤트 구독
+        playerInput.OnToggleShadowEvent += HandleToggleShadow;
+    }
+
+     private void OnDestroy()
+    {
+        // 이벤트 구독 해지
+        if (playerInput != null)
+        {
+            playerInput.OnToggleShadowEvent -= HandleToggleShadow;
+        }
+    }
+
+
+    private void Update() // FixedUpdate 대신 Update 사용 권장 (매 프레임 시각적 업데이트)
+    {
+        // 점프 시 그림자 처리
+        HandleShadowOnJump();
+    }
+
+    /// <summary>
+    /// PlayerInput의 OnToggleShadowEvent 신호를 받아 그림자 모드를 토글합니다.
+    /// </summary>
+    private void HandleToggleShadow()
+    {
+        isShadowModeActive = !isShadowModeActive; // 그림자 모드 상태를 뒤집습니다.
+        UpdateShadowVisuals();
+    }
+
+    /// <summary>
+    /// 그림자 모드 상태에 따라 플레이어와 그림자의 모습을 업데이트합니다.
+    /// </summary>
+    private void UpdateShadowVisuals()
+    {
+        if (isShadowModeActive)
+        {
+            // 그림자 모드 활성화: 그림자 끄고, 플레이어 검게
+            shadowObject.SetActive(false);
+            playerSpriteRenderer.color = Color.black;
+        }
+        else
+        {
+            // 그림자 모드 비활성화: 플레이어 색상 원래대로, 그림자는 지면 상태에 따라 결정
+            playerSpriteRenderer.color = originalPlayerColor;
+            HandleShadowOnJump(); // 점프 상태에 맞게 그림자를 즉시 업데이트
+        }
+    }
+
+    /// <summary>
+    /// 플레이어의 지면 상태에 따라 그림자를 켜고 끕니다.
+    /// (그림자 모드가 아닐 때만 작동)
+    /// </summary>
+    private void HandleShadowOnJump()
+    {
+        // C키로 그림자 모드가 켜져있다면, 이 로직은 무시됩니다.
+        if (isShadowModeActive) return;
+
+        // PlayerLocomotion의 Grounded 프로퍼티를 사용하여 지면 상태를 확인합니다.
+        if (playerLocomotion.Grounded)
+        {
+            shadowObject.SetActive(true); // 땅에 있으면 그림자 켜기
+        }
+        else
+        {
+            shadowObject.SetActive(false); // 공중에 있으면 그림자 끄기
+        }
+    }
+}
+

--- a/Assets/Scripts/Player/PlayerShadowController.cs.meta
+++ b/Assets/Scripts/Player/PlayerShadowController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ee6ca2f2915693240980f80926f4e45d


### PR DESCRIPTION
📦 PR - [Player] refactor : 섀도우 컨트롤러, 로코모션에서 분리

📋 Summary

기존 PlayerLocomotion에 포함되어 있던 그림자 변신 및 점프 시 그림자 제어 로직을 새로운 PlayerShadowController 스크립트로 분리하여 코드의 책임과 응집도를 개선함

🔗 Related Issue

Closes #41 

🔧 Changes Made

PlayerLocomotion.cs: 그림자 관련 변수(shadowObject, originalPlayerColor, isShadowModeActive), 이벤트 구독/해지 코드, 관련 함수(HandleToggleShadow, UpdateShadowVisuals, HandleShadowOnJump)를 모두 제거

PlayerShadowController.cs: 새로운 스크립트를 생성하여 제거된 모든 그림자 제어 로직을 이전
PlayerInput의 OnToggleShadowEvent를 구독하고 PlayerLocomotion의 Grounded 프로퍼티를 참조하여 작동


📸 Screenshots (Optional)



🧪 How to Test

그림자 기능이 정상작동하는지 확인
PlayerLocomotion.cs 코드에 더 이상 그림자 관련 로직이 없는지 확인