### PR TITLE
[Enemy] feat : Enemy Item Drop

### DIFF
--- a/Assets/Scripts/Enemy/LootDropper.cs
+++ b/Assets/Scripts/Enemy/LootDropper.cs
@@ -1,0 +1,68 @@
+using UnityEngine;
+using System.Collections.Generic;
+
+/// <summary>
+/// 적 사망 시 확률에 따른 아이템 드롭을 담당하는 클래스
+/// 드롭 시 리스트에 등록된 아이템 중 무작위로 선택하여 월드에 생성
+/// </summary>
+public class LootDropper : MonoBehaviour
+{
+    [System.Serializable]
+    // 전리품 아이템 클래스 정의
+    public class LootItem
+    {
+        [Header("Loot Settings")]
+        // 드롭할 전리품 아이템 프리팹
+        public GameObject itemPrefab;
+    }
+
+    [Range(0f, 1f)]
+    [SerializeField] private float dropChance = 0.5f; // 아이템 드롭 확률
+
+    [Header("Loot Item List")]
+    [SerializeField] private List<LootItem> lootItemList = new List<LootItem>();
+
+    public void DropLoot()
+    {
+        // 아이템 드롭 여부 결정
+        float randomDropCheck = Random.Range(0f, 1f);
+
+        // 드롭 확률보다 작을 경우 드롭 실패
+        if (randomDropCheck < dropChance)
+        {
+            return;
+        }
+
+        // 아이템 리스트 비어있는지 확인
+        if (lootItemList.Count == 0)
+        {
+            Debug.LogWarning("LootDropper : 아이템 리스트가 비어있습니다.");
+            return;
+        }
+
+        // 드롭 성공 시, 아이템 리스트에서 무작위로 하나 선택
+        int randomIndex = Random.Range(0, lootItemList.Count);
+        LootItem selectedLoot = lootItemList[randomIndex];
+
+        // 선택된 아이템 드롭 실행
+        if (selectedLoot != null)
+        {
+            Vector3 dropPosition = transform.position;
+            InstantiateItem(selectedLoot.itemPrefab, dropPosition);
+        }
+
+    }
+
+    private void InstantiateItem(GameObject itemPrefab, Vector3 position)
+    {
+        if (itemPrefab == null)
+        {
+            Debug.LogWarning("드롭할 아이템 프리팹이 설정되지 않았습니다! - " + gameObject.name);
+            return;
+        }
+
+        // 드롭 위치에 아이템 프리팹 생성
+        Instantiate(itemPrefab, position, Quaternion.identity);
+        Debug.Log($"아이템 드롭 성공! {itemPrefab.name.Replace("(Clone)", "")} 생성됨.");
+    }
+}

--- a/Assets/Scripts/Enemy/LootDropper.cs.meta
+++ b/Assets/Scripts/Enemy/LootDropper.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b3cf85136d71a08438d5ab635c708289


### PR DESCRIPTION
## 📦 PR - [Enemy] feat : 적 아이템 드롭

### 📋 Summary
적이 사망 시 확률에 따라 아이템을 드롭하는 로직 구현

### 🔗 Related Issue
**Closes #46 **

### 🔧 Changes Made
- `LootDropper.cs` : 확률에 따라 아이템 드롭 로직 구현 
                                드롭 시 리스트에 등록된 아이템 중 무작위 선택되어 월드에 생성

### 🧪 How to Test
테스트를 거친 PR로 ContextMenu를 통해 DropLoot() 테스트 결과 정상 동작하는 것을 확인.
(리스트에 등록된 아이템 중 무작위로 선택되어 적의 위치에 생성되는 것도 확인.)

### Memo
적 사망 상태에 대한 구현이 되어있지 않아 사망 시 실행 로직에 아이템 드롭 로직을 추가하지 못했습니다.
(Enemy 기능 담당자가 이 부분을 구현할 필요가 있습니다.)
