### PR TITLE
refactor(player): hpbar bug fix

### DIFF
--- a/Assets/Scripts/Core/StatManager.cs
+++ b/Assets/Scripts/Core/StatManager.cs
@@ -244,6 +244,27 @@ public class StatManager : MonoBehaviour
         currentStamina = Mathf.Min(currentStamina + amount, MaxStamina);
         OnStaminaChanged?.Invoke(this, currentStamina, MaxStamina);
     }
+
+    /// <summary>
+    /// 방어력을 무시하고 HP를 즉시 감소시킵니다. (그림자 모드 변신 비용 등)
+    /// 이 함수는 '피격'으로 간주되지 않으므로 OnHurt 이벤트를 호출하지 않습니다.
+    /// </summary>
+    public void ApplyDirectHPLoss(float amount)
+    {
+        // 순수 데미지만큼 HP 감소
+        currentHP = Mathf.Max(currentHP - amount, 0);
+        
+        // [중요] UI 컨트롤러에 신호를 보냅니다.
+        OnHPChanged?.Invoke(this, currentHP, MaxHP);
+
+        // HP가 0이 되면 사망 이벤트는 동일하게 호출
+        if (currentHP <= 0)
+        {
+            // OnDeath 이벤트는 이미 구독되어 있으므로
+            // PlayerDamageStateManager가 사망 처리를 할 것입니다.
+            OnDeath?.Invoke();
+        }
+    }
     #endregion
 
 }

--- a/Assets/Scripts/Player/PlayerShadowController.cs
+++ b/Assets/Scripts/Player/PlayerShadowController.cs
@@ -11,198 +11,209 @@ using System;
 [RequireComponent(typeof(SpriteRenderer), typeof(PlayerLocomotion), typeof(StatManager))]
 public class PlayerShadowController : MonoBehaviour, IStatSource
 {
-    [Header("오브젝트 연결")]
-    [Tooltip("플레이어의 자식 오브젝트인 Shadow를 연결해주세요.")]
-    [SerializeField] private GameObject shadowObject;
+    [Header("오브젝트 연결")]
+    [Tooltip("플레이어의 자식 오브젝트인 Shadow를 연결해주세요.")]
+    [SerializeField] private GameObject shadowObject;
 
-    [Header("섀도우 모드 버프/디버프 수치")]
-    [Tooltip("공격력 증가량 (예: 0.2f = 20% 증가)")]
-    [SerializeField] private float attackPowerBonus = 0.2f;
-    [Tooltip("이동 속도 배율 (예: 1.3f = 30% 증가)")]
-    [SerializeField] private float moveSpeedMultiplierBonus = 1.3f;
-    [Tooltip("최대 체력 감소량 (예: -0.5f = 50% 감소)")]
-    [SerializeField] private float maxHpDebuff = -0.5f;
-
-    [Header("레이어 설정 (Layer Settings)")]
-    [Tooltip("플레이어의 기본 레이어 이름 (예: Default)")]
-    [SerializeField] private string playerLayerName = "Default"; // "Player"에서 "Default"로 변경
-    [Tooltip("섀도우 모드일 때 사용할 레이어 이름 (예: PlayerShadow)")]
-    [SerializeField] private string playerShadowLayerName = "PlayerShadow";
-
-    // 컴포넌트 참조
-    private SpriteRenderer playerSpriteRenderer;
-    private PlayerLocomotion playerLocomotion;
-    private PlayerInput playerInput;
-    private StatManager statManager;
-
-    // 내부 상태 변수
-    private Color originalPlayerColor;
-    private bool isShadowModeActive = false;
-
-    // 스탯 보정치 객체
-    private StatModifier attackBuff;
-    private StatModifier maxHpDebuffModifier;
+    [Header("섀도우 모드 버프/디버프 수치")]
+    [Tooltip("공격력 증가량 (예: 0.2f = 20% 증가)")]
+    [SerializeField] private float attackPowerBonus = 0.2f;
+    [Tooltip("이동 속도 배율 (예: 1.3f = 30% 증가)")]
+    [SerializeField] private float moveSpeedMultiplierBonus = 1.3f;
     
-    // 레이어 인덱스 저장
-    private int playerLayer;
-    private int playerShadowLayer;
+    // [주석 처리됨] MaxHP 디버프 대신 CurrentHP 코스트 소모 방식을 사용합니다.
+    // [Tooltip("최대 체력 감소량 (예: -0.5f = 50% 감소)")]
+    // [SerializeField] private float maxHpDebuff = -0.5f;
 
-    #region IStatSource implementation
-    public int SourceID => GetInstanceID();
-    #endregion
+    [Header("레이어 설정 (Layer Settings)")]
+    [Tooltip("플레이어의 기본 레이어 이름 (예: Default)")]
+    [SerializeField] private string playerLayerName = "Default"; // "Player"에서 "Default"로 변경
+    [Tooltip("섀도우 모드일 때 사용할 레이어 이름 (예: PlayerShadow)")]
+    [SerializeField] private string playerShadowLayerName = "PlayerShadow";
 
-    public bool IsShadowModeActive => isShadowModeActive;
+    // 컴포넌트 참조
+    private SpriteRenderer playerSpriteRenderer;
+    private PlayerLocomotion playerLocomotion;
+    private PlayerInput playerInput;
+    private StatManager statManager;
 
-    private void Awake()
-    {
-        // 1. 모든 필수 컴포넌트를 가져옵니다.
-        playerSpriteRenderer = GetComponent<SpriteRenderer>();
-        playerLocomotion = GetComponent<PlayerLocomotion>();
-        playerInput = GetComponent<PlayerInput>();
-        statManager = GetComponent<StatManager>();
+    // 내부 상태 변수
+    private Color originalPlayerColor;
+    private bool isShadowModeActive = false;
 
-        // 2. 오브젝트 연결 확인
-        if (shadowObject == null)
-        {
-            Debug.LogError("Shadow 오브젝트가 연결되지 않았습니다! 인스펙터 창에서 연결해주세요.", this);
-            enabled = false; return;
-        }
-        if (playerInput == null)
-        {
-            Debug.LogError("PlayerInput 컴포넌트를 찾을 수 없습니다!", this);
-            enabled = false; return;
-        }
+    // 스탯 보정치 객체
+    private StatModifier attackBuff;
+    // [삭제됨] private StatModifier maxHpDebuffModifier;
+    
+    // 레이어 인덱스 저장
+    private int playerLayer;
+    private int playerShadowLayer;
+
+    #region IStatSource implementation
+    public int SourceID => GetInstanceID();
+    #endregion
+
+    public bool IsShadowModeActive => isShadowModeActive;
+
+    private void Awake()
+    {
+        // 1. 모든 필수 컴포넌트를 가져옵니다.
+        playerSpriteRenderer = GetComponent<SpriteRenderer>();
+        playerLocomotion = GetComponent<PlayerLocomotion>();
+        playerInput = GetComponent<PlayerInput>();
+        statManager = GetComponent<StatManager>();
+
+        // 2. 오브젝트 연결 확인
+        if (shadowObject == null)
+        {
+            Debug.LogError("Shadow 오브젝트가 연결되지 않았습니다! 인스펙터 창에서 연결해주세요.", this);
+            enabled = false; return;
+        }
+        if (playerInput == null)
+        {
+            Debug.LogError("PlayerInput 컴포넌트를 찾을 수 없습니다!", this);
+            enabled = false; return;
+        }
+        
+        // 3. 레이어 이름(string)을 레이어 인덱스(int)로 변환하여 저장
+        playerLayer = LayerMask.NameToLayer(playerLayerName);
+        playerShadowLayer = LayerMask.NameToLayer(playerShadowLayerName);
+
+        if (playerLayer == -1) // playerLayerName이 "Default"인 경우 0을 반환하므로 -1이 아님.
+        {
+            // "Default" 레이어는 항상 인덱스 0을 반환하며 -1이 될 수 없습니다. 
+            // 혹시 "Default"가 아닌 다른 잘못된 이름이 인스펙터에 입력되었을 경우를 대비한 방어 코드입니다.
+            if (playerLayerName != "Default") {
+                Debug.LogError($"'{playerLayerName}' 레이어를 찾을 수 없습니다. Project Settings > Tags and Layers에서 레이어 이름을 확인하세요.", this);
+                enabled = false; return;
+            }
+        }
+        if (playerShadowLayer == -1)
+        {
+            Debug.LogError($"'PlayerShadow' 레이어를 찾을 수 없습니다. Project Settings > Tags and Layers에서 '{playerShadowLayerName}' 레이어를 생성했는지 확인하세요.", this);
+            enabled = false; return;
+        }
+
+        // 4. 플레이어 원래 색상 저장
+        originalPlayerColor = playerSpriteRenderer.color;
+
+        // 5. 스탯 보정치 객체 생성
+        attackBuff = new StatModifier(attackPowerBonus, StatModType.Multiplicative, this);
         
-        // 3. 레이어 이름(string)을 레이어 인덱스(int)로 변환하여 저장
-        playerLayer = LayerMask.NameToLayer(playerLayerName);
-        playerShadowLayer = LayerMask.NameToLayer(playerShadowLayerName);
+        // [수정됨] MaxHP 디버프 보정치 생성 로직 삭제
+        // maxHpDebuffModifier = new StatModifier(maxHpDebuff, StatModType.Multiplicative, this);
 
-        if (playerLayer == -1) // playerLayerName이 "Default"인 경우 0을 반환하므로 -1이 아님.
-        {
-            // "Default" 레이어는 항상 인덱스 0을 반환하며 -1이 될 수 없습니다. 
-            // 혹시 "Default"가 아닌 다른 잘못된 이름이 인스펙터에 입력되었을 경우를 대비한 방어 코드입니다.
-            if (playerLayerName != "Default") {
-                Debug.LogError($"'{playerLayerName}' 레이어를 찾을 수 없습니다. Project Settings > Tags and Layers에서 레이어 이름을 확인하세요.", this);
-                enabled = false; return;
-            }
-        }
-        if (playerShadowLayer == -1)
-        {
-            Debug.LogError($"'PlayerShadow' 레이어를 찾을 수 없습니다. Project Settings > Tags and Layers에서 '{playerShadowLayerName}' 레이어를 생성했는지 확인하세요.", this);
-            enabled = false; return;
-        }
+        // 6. PlayerInput의 'c' 키 이벤트 구독
+        playerInput.OnToggleShadowEvent += HandleToggleShadow;
+    }
 
-        // 4. 플레이어 원래 색상 저장
-        originalPlayerColor = playerSpriteRenderer.color;
+    private void OnDestroy()
+    {
+        if (playerInput != null)
+        {
+            playerInput.OnToggleShadowEvent -= HandleToggleShadow;
+        }
+        if (isShadowModeActive && statManager != null)
+        {
+            RemoveShadowModeBuffs();
+        }
+    }
 
-        // 5. 스탯 보정치 객체 생성
-        attackBuff = new StatModifier(attackPowerBonus, StatModType.Multiplicative, this);
-        maxHpDebuffModifier = new StatModifier(maxHpDebuff, StatModType.Multiplicative, this);
+    private void Update()
+    {
+        HandleShadowOnJump();
+    }
 
-        // 6. PlayerInput의 'c' 키 이벤트 구독
-        playerInput.OnToggleShadowEvent += HandleToggleShadow;
-    }
+    /// <summary>
+    /// 'c' 키 입력 신호를 받아 섀도우 모드를 토글합니다.
+    /// </summary>
+    private void HandleToggleShadow()
+    {
+        isShadowModeActive = !isShadowModeActive; // 모드 상태 반전
 
-    private void OnDestroy()
-    {
-        if (playerInput != null)
-        {
-            playerInput.OnToggleShadowEvent -= HandleToggleShadow;
-        }
-        if (isShadowModeActive && statManager != null)
-        {
-            RemoveShadowModeBuffs();
-        }
-    }
+        // --- 레이어 변경 로직 ---
+        if (isShadowModeActive)
+        {
+            gameObject.layer = playerShadowLayer;
+        }
+        else
+        {
+            gameObject.layer = playerLayer;
+        }
+        // -------------------------
 
-    private void Update()
-    {
-        HandleShadowOnJump();
-    }
+        UpdateShadowVisuals();
+        UpdateShadowModeStats();
+    }
 
-    /// <summary>
-    /// 'c' 키 입력 신호를 받아 섀도우 모드를 토글합니다.
-    /// </summary>
-    private void HandleToggleShadow()
-    {
-        isShadowModeActive = !isShadowModeActive; // 모드 상태 반전
+    /// <summary>
+    /// 섀도우 모드 상태에 따라 시각적 효과(색상, 그림자)를 업데이트합니다.
+    /// </summary>
+    private void UpdateShadowVisuals()
+    {
+        if (isShadowModeActive)
+        {
+            shadowObject.SetActive(false);
+            playerSpriteRenderer.color = Color.black;
+        }
+        else
+        {
+            playerSpriteRenderer.color = originalPlayerColor;
+            HandleShadowOnJump(); 
+        }
+    }
 
-        // --- 레이어 변경 로직 ---
-        if (isShadowModeActive)
-        {
-            gameObject.layer = playerShadowLayer;
-        }
-        else
-        {
-            gameObject.layer = playerLayer;
-        }
-        // -------------------------
+    /// <summary>
+    /// 섀도우 모드 상태에 따라 버프/디버프를 적용하거나 제거합니다.
+    /// </summary>
+    private void UpdateShadowModeStats()
+    {
+        if (isShadowModeActive)
+        {
+            statManager.AddModifier(StatType.AttackPower, attackBuff);
+            
+            // [수정됨] MaxHP를 깎는 대신, 현재 HP의 절반을 '비용'으로 지불합니다.
+            // (StatManager에 ApplyDirectHPLoss 함수가 추가되어 있어야 합니다)
+            float hpCost = statManager.CurrentHP / 2f;
+            statManager.ApplyDirectHPLoss(hpCost);
 
-        UpdateShadowVisuals();
-        UpdateShadowModeStats();
-    }
-
-    /// <summary>
-    /// 섀도우 모드 상태에 따라 시각적 효과(색상, 그림자)를 업데이트합니다.
-    /// </summary>
-    private void UpdateShadowVisuals()
-    {
-        if (isShadowModeActive)
-        {
-            shadowObject.SetActive(false);
-            playerSpriteRenderer.color = Color.black;
-        }
-        else
-        {
-            playerSpriteRenderer.color = originalPlayerColor;
-            HandleShadowOnJump(); 
-        }
-    }
-
-    /// <summary>
-    /// 섀도우 모드 상태에 따라 버프/디버프를 적용하거나 제거합니다.
-    /// </summary>
-    private void UpdateShadowModeStats()
-    {
-        if (isShadowModeActive)
-        {
-            statManager.AddModifier(StatType.AttackPower, attackBuff);
-            statManager.AddModifier(StatType.MaxHP, maxHpDebuffModifier);
-            playerLocomotion.MoveSpeedMultiplier = moveSpeedMultiplierBonus;
-            Debug.Log("섀도우 모드 활성화: 기믹 통과, 스탯 변경");
-        }
-        else
-        {
-            RemoveShadowModeBuffs();
-            Debug.Log("섀도우 모드 비활성화: 모든 스탯/레이어 원상 복구");
-        }
-    }
-
-    /// <summary>
-    /// StatManager와 PlayerLocomotion에서 모든 섀도우 모드 보정치를 제거합니다.
-    /// </summary>
-    private void RemoveShadowModeBuffs()
-    {
-        statManager.RemoveModifier(StatType.AttackPower, this);
-        statManager.RemoveModifier(StatType.MaxHP, this);
-        playerLocomotion.MoveSpeedMultiplier = 1f; 
-    }
-
-    /// <summary>
-    /// 플레이어의 지면 상태에 따라 시각적 그림자를 켜고 끕니다. (섀도우 모드가 아닐 때만)
-    /// </summary>
-    private void HandleShadowOnJump()
-    {
-        if (isShadowModeActive) return;
-
-        if (playerLocomotion.Grounded)
-        {
-            shadowObject.SetActive(true);
-        }
-        else
-        {
-            shadowObject.SetActive(false);
-        }
-    }
+            playerLocomotion.MoveSpeedMultiplier = moveSpeedMultiplierBonus;
+            Debug.Log("섀도우 모드 활성화: 기믹 통과, 스탯 변경, HP 코스트 지불");
+        }
+        else
+        {
+            RemoveShadowModeBuffs();
+            Debug.Log("섀도우 모드 비활성화: 모든 스탯/레이어 원상 복구");
 }
+    }
 
+    /// <summary>
+    /// StatManager와 PlayerLocomotion에서 모든 섀도우 모드 보정치를 제거합니다.
+    /// </summary>
+    private void RemoveShadowModeBuffs()
+    {
+        statManager.RemoveModifier(StatType.AttackPower, this);
+        
+        // [수정됨] MaxHP 보정치 제거 로직 삭제
+        // statManager.RemoveModifier(StatType.MaxHP, this);
+        
+        playerLocomotion.MoveSpeedMultiplier = 1f; 
+    }
+
+    /// <summary>
+    /// 플레이어의 지면 상태에 따라 시각적 그림자를 켜고 끕니다. (섀도우 모드가 아닐 때만)
+    /// </summary>
+    private void HandleShadowOnJump()
+    {
+        if (isShadowModeActive) return;
+
+        if (playerLocomotion.Grounded)
+        {
+            shadowObject.SetActive(true);
+        }
+        else
+        {
+            shadowObject.SetActive(false);
+        }
+    }
+}


### PR DESCRIPTION
📦 PR - [Player] refactor : hpbar bug fix

📋 Summary
그림자 모드 진입 시 MaxHP를 깎는 방식(50/50=100%)으로 인해 HP 바가 갱신되지 않던 버그를 수정합니다. MaxHP 디버프 대신 currentHP를 '비용'으로 즉시 차감하는 방식으로 리팩토링하여 UI가 즉각 반응하도록 수정합니다.

🔗 Related Issue
Closes #이슈번호 (여기에 관련 이슈 번호를 넣어주세요)

🔧 Changes Made
StatManager.cs 수정: ApplyDirectHPLoss() 함수를 신규 추가했습니다. 이 함수는 방어력을 무시하고 currentHP를 즉시 차감하며, OnHPChanged 이벤트를 Invoke하여 UI에 즉시 신호를 보냅니다.
PlayerShadowController.cs 리팩토링:
MaxHP 디버프 보정치(maxHpDebuffModifier) 관련 로직을 모두 제거했습니다.
HandleToggleShadow() > UpdateShadowModeStats() 함수가 MaxHP를 깎는 대신, statManager.ApplyDirectHPLoss(hpCost)를 호출하도록 변경했습니다. (현재 HP의 절반을 '비용'으로 소모)

📸 Screenshots (Optional)

🧪 How to Test
게임을 시작합니다.

HP 바가 Background 테두리에 빈틈없이 100%로 꽉 차 있는지 확인합니다. (Padding/Trim 버그 픽스 확인)

'C' 키를 눌러 그림자 모드로 진입합니다.

HP 바가 100%가 아닌, 50%로 즉시 깎이는지 확인합니다. (핵심 버그 픽스 확인)

'C' 키를 다시 눌러 그림자 모드를 해제했을 때, HP 바가 50% 상태를 유지하는지 확인합니다. (HP 코스트가 정상 차감되었는지 확인)